### PR TITLE
Alchemy NFT Provider: ensure NFT metadata name field is always a string

### DIFF
--- a/packages/sdk/src/nft/providers/alchemy-nft.provider.ts
+++ b/packages/sdk/src/nft/providers/alchemy-nft.provider.ts
@@ -26,7 +26,7 @@ export abstract class AlchemyNftProvider extends BaseNftProvider {
             type: this.extractNftType(nft.tokenType) || undefined,
           },
           metadata: {
-            name: nft!.rawMetadata!.name || "",
+            name: String(nft!.rawMetadata!.name) || "",
             description: nft!.rawMetadata!.description || "",
             image: nft!.rawMetadata!.image || "",
           },


### PR DESCRIPTION
Some NFTs have numbers in the `metadata.name` field instead of strings which causes unexpected behavior when using string methods. Normalize this field using `String()` for consistency.

[Example](https://opensea.io/collection/surge-passport) (contract address: `0x0632adcab8f12edd3b06f99dc6078fe1fedd32b0`)